### PR TITLE
Allow use of variants via http header without updating route state.

### DIFF
--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -225,7 +225,12 @@ _.extend(Route.prototype, {
   },
 
   activeVariant: function(request) {
-    return this._mocker.state.routeState(request)[this._id]._activeVariant;
+    const variantFromRequestHeader = request.headers['x-request-variant']; 
+    const variantFromRouteState = this._mocker.state.routeState(request)[this._id]._activeVariant;
+
+    // x-request-variant request header takes precedence over variant set in state
+    // causes an http 500 response status code if a variant is set that doesn't actually exist
+    return variantFromRequestHeader || variantFromRouteState;
   },
 
   done: function() {


### PR DESCRIPTION
This change is backwards compatible with existing variant logic set in route state.

It adds the ability for a client to pass a `x-request-variant` header.  When doing so, the variant in the header will be used instead of whatever is set in route state for that single request.

I have a use case in test automation where this capability greatly simplifies my logic as it removes the need for managing session state, when a client wants a variant it simply asks for it without impacting the rest of the world or having to deal with a session.

### Example
With `/message` call from test data in `midway/resources/endpoint.js` using the header

![image](https://user-images.githubusercontent.com/51921135/74978915-2f10a600-53f3-11ea-9300-71e67a8e5fc5.png)


and without the header (existing behavior)
![image](https://user-images.githubusercontent.com/51921135/74978857-16a08b80-53f3-11ea-81ea-144cd10ba9ad.png)
