### PR TITLE
Session: Light weight alternative using header instead of routes

### DIFF
--- a/lib/admin/api/reset-session-variant-state-by-key.js
+++ b/lib/admin/api/reset-session-variant-state-by-key.js
@@ -1,0 +1,9 @@
+module.exports = function (mocker) {
+    return function (request, reply, respondWithConfig) {
+      var key = request.params.key;
+      mocker.state.resetSessionVariantStateByKey(request, key);
+  
+      reply(respondWithConfig ? formatData(mocker, request) : {});
+    };
+  };
+  

--- a/lib/admin/api/reset-session-variant-state.js
+++ b/lib/admin/api/reset-session-variant-state.js
@@ -1,0 +1,9 @@
+var formatData = require("./format-data");
+
+module.exports = function (mocker) {
+  return function (request, reply, respondWithConfig) {
+    mocker.state.resetSessionVariantState(request);
+
+    reply(respondWithConfig ? formatData(mocker, request) : {});
+  };
+};

--- a/lib/admin/api/set-session-variant-state-by-key.js
+++ b/lib/admin/api/set-session-variant-state-by-key.js
@@ -1,0 +1,11 @@
+var formatData = require("./format-data");
+
+module.exports = function (mocker) {
+  return function (request, reply, respondWithConfig) {
+    var key = request.params.key;
+    var payload = request.payload;
+    mocker.state.setSessionVariantStateByKey(request, key, payload);
+
+    reply(respondWithConfig ? formatData(mocker, request) : {});
+  };
+};

--- a/lib/admin/index.js
+++ b/lib/admin/index.js
@@ -93,6 +93,46 @@ module.exports = function(server, mocker) {
   });
 
   connection.route({
+    method: "POST",
+    path: MIDWAY_API_PATH + "/sessionVariantState/reset",
+    handler: ensureInitialized(function (request, reply, respondWithConfig) {
+      reply = wrapReply(request, reply);
+      require("./api/reset-session-variant-state")(mocker)(
+        request,
+        reply,
+        respondWithConfig
+      );
+    }),
+  });
+
+  connection.route({
+    method: "POST",
+    path: MIDWAY_API_PATH + "/sessionVariantState/reset/{key}",
+    handler: ensureInitialized(function (request, reply, respondWithConfig) {
+       reply = wrapReply(request, reply);
+      require("./api/reset-session-variant-state-by-key")(mocker)(
+        request,
+        reply,
+        respondWithConfig
+      );
+    }),
+  });
+
+  connection.route({
+    method: "POST",
+    path: MIDWAY_API_PATH + "/sessionVariantState/set/{key}",
+    handler: ensureInitialized(function (request, reply, respondWithConfig) {
+      reply = wrapReply(request, reply);
+      require("./api/set-session-variant-state-by-key")(mocker)(
+        request,
+        reply,
+        respondWithConfig
+      );
+    }),
+  });
+
+
+  connection.route({
     method: 'POST',
     path: MIDWAY_API_PATH + '/input/reset',
     handler: ensureInitialized(function(request, reply, respondWithConfig) {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -198,8 +198,8 @@ _.extend(Route.prototype, {
     }
   },
 
-  getActiveVariant: function(request) {
-    var id = this.activeVariant(request);
+  getActiveVariant: function (request, sessionState, routeId) {
+    var id = this.activeVariant(request, sessionState, routeId);
     return _.find(this.variants(), function(variant) {
       return variant.id() === id;
     });
@@ -224,13 +224,20 @@ _.extend(Route.prototype, {
     return variant.respondWithFile(options);
   },
 
-  activeVariant: function(request) {
+  activeVariant: function(request, sessionState, routeId) {
     const variantFromRequestHeader = request.headers['x-request-variant']; 
     const variantFromRouteState = this._mocker.state.routeState(request)[this._id]._activeVariant;
 
+    const sessionFromRequestHeader = request.headers["x-request-session"];
+    let variantFromSession;
+    if (sessionState && routeId && sessionFromRequestHeader && sessionState[sessionFromRequestHeader]) {
+      variantFromSession = sessionState[sessionFromRequestHeader][routeId];
+    }
+
     // x-request-variant request header takes precedence over variant set in state
     // causes an http 500 response status code if a variant is set that doesn't actually exist
-    return variantFromRequestHeader || variantFromRouteState;
+    return variantFromRequestHeader || variantFromSession || variantFromRouteState;
+
   },
 
   done: function() {
@@ -359,11 +366,13 @@ _.extend(Route.prototype, {
   _handleRequest: function(request, reply) {
     var self = this;
     var mocker = this._mocker;
-    var variant = this.getActiveVariant(request);
+
+    var sessionState = mocker.state.sessionVariantState(request);
+    var variant = this.getActiveVariant(request, sessionState, this._id);
 
     if (variant) {
       if (variant.handler) {
-        return variant.handler.call(executionContext(this, request), request, reply);
+        return variant.handler.call(executionContext(this, request, variant), request, reply);
       } else {
         Logger.error('no variant handler found for ' + this._path + ':' + variant.id());
         reply('no variant handler found for ' + this._path + ':' + variant.id()).code(500);
@@ -389,8 +398,11 @@ _.extend(Route.prototype, {
 
 module.exports = Route;
 
-function executionContext(route, request) {
-  var variant = route.getActiveVariant(request);
+function executionContext(route, request, preComputedVariant) {
+  var variant = preComputedVariant
+  ? preComputedVariant
+  : route.getActiveVariant(request);
+
   return {
     state: function(id, value) {
       var details = {

--- a/lib/route-model.js
+++ b/lib/route-model.js
@@ -225,7 +225,12 @@ _.extend(Route.prototype, {
   },
 
   activeVariant: function(request) {
-    return this._mocker.state.routeState(request)[this._id]._activeVariant;
+    const variantFromRequestHeader = request.headers['x-request-variant']; 
+    const variantFromRouteState = this._mocker.state.routeState(request)[this._id]._activeVariant;
+
+    // x-request-variant request header takes precedence over variant set in state
+    // causes an http 500 response status code if a variant is set that doesn't actually exist
+    return variantFromRequestHeader || variantFromRouteState;
   },
 
   done: function() {

--- a/lib/state/static-state.js
+++ b/lib/state/static-state.js
@@ -15,6 +15,7 @@ var _ = require('lodash');
 var doInitialize = true;
 var ROUTE_STATE = {};
 var USER_STATE = {};
+var SESSION_VARIANT_STATE = {};
 
 module.exports = {
   initialize: function(request, callback) {
@@ -37,6 +38,22 @@ module.exports = {
 
   resetRouteState: function(request) {
     ROUTE_STATE = {};
+  },
+
+  sessionVariantState: function (request) {
+    return SESSION_VARIANT_STATE;
+  },
+
+  resetSessionVariantState: function (request) {
+    SESSION_VARIANT_STATE = {};
+  },
+
+  resetSessionVariantStateByKey: function (request, key) {
+    delete SESSION_VARIANT_STATE[key];
+  },
+
+  setSessionVariantStateByKey: function (request, key, payload) {
+    SESSION_VARIANT_STATE[key] = payload;
   },
 
   onResponse: function(request, reply) {


### PR DESCRIPTION
### What this PR introduces
An alternative way to manage permutations of variants compared to the existing route based session approach.  This PR does not remove or change any existing session behavior, only adds a new alternative.  I am aware you can already pass a session in the header `x-request-page-params: {"midwaySessionId": "someSessionID"}`, this does not interfere with that.

### Problem
While midway/smocks is very helpful, there were serious performance issues when running multiple sessions, as multiple sessions create extra hapi routes.

I have roughly 250 routes with 0 sessions and here were some numbers on startup speed when leveraging sessions.

- 466 routes took 280ms to load (1 session)
- 1370 routes took 1036ms to load (5 sessions) 
- 4760 routes took 12229ms to load (20 sessions)
- 80 sessions took over 5 minutes to load

as you can see performance, at least around startup, only gets worse the more sessions added.  

Here is the node profiler on trying to start 5 sessions.
![image](https://user-images.githubusercontent.com/51921135/88830325-6d28a780-d193-11ea-8e45-c93f2a50578e.png)

You can see it get much worse when I try 80 sessions (5 minute startup).
![image](https://user-images.githubusercontent.com/51921135/88827475-a101ce00-d18f-11ea-9467-4528b22759af.png)

I also noticed the more routes in memory, the slower it took to add new routes.
![image](https://user-images.githubusercontent.com/51921135/88828987-9b0cec80-d191-11ea-8bef-19414d29520d.png)

![image](https://user-images.githubusercontent.com/51921135/88829071-baa41500-d191-11ea-9674-88d23173cb35.png)



And here is a separate profiler on the memory (This was running ~50 sessions I believe)
![image](https://user-images.githubusercontent.com/51921135/88827323-71eb5c80-d18f-11ea-963e-947a2d28a0c0.png)

I have a use case where I want to run ~150 parallel sessions and maintaining a 1:1 relationship between routes and sessions will not suffice.  

### How this PR solves it
All I want is to "bucket" permutations of variants.  E.g. client1 and client 2 should be able to work in parallel without stepping on each other's toes when setting variants.  I believe this is the exact problem midway sessions set to solve.

Instead of duplicating route instances per session I'm perfectly fine using a header to drive this behavior, keeping total routes for 150 sessions (in my use case) to ~250 instead of ~40K.  The solution set upon in this PR is to pass an ID in the header, using an in-memory object to drive when the variant should be applied based on key:value pairs.  

For example in memory state driving this behavior may look like
```js
{ 
   "0": { 
      "GET /some/url/defined/in/midway": "someVariantInMidway",
      "GET /some/other/url/defined/in/midway": "someOtherVariantInMidway"
   },
   "AnotherKey": { ... and so on ... }
}
```

I leave it up to the client to choose the key, that means it is a client responsibility to avoid collision with other clients running in parallel.  Since these midway instances will be (in my case) ephemeral and the clients consuming midway will know which IDs they are I don't see it as a problem.

Example setting variants for a session, in this case session id "3", would look like
```
POST midway/api/sessionVariantState/set/3
{ "GET /some/url/defined/in/midway": "someVariantInMidway" }
```

Provided the above call was made to set state, when a request to `GET /some/url/defined/in/midway` has the header `x-request-session: 3` it will load the `someVariantInMidway` variant for the request.  

This satisfies my use case without creating ~40,000 routes (250 routes * 150 sessions).

### Additional comments
- Do note this PR doesn't add any UI, so this cannot be set via the admin console, but it does add the necessary admin API calls.
- This PR also includes the commit of my [previous open PR](https://github.com/TestArmada/midway-smocks/pull/1) 